### PR TITLE
use transient storage for TendConfig and include a Keeper contract to simplify maintenance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,7 +11,7 @@
 [submodule "lib/hyperdrive"]
 	path = lib/hyperdrive
 	url = https://github.com/delvtech/hyperdrive
-  branch = v1.0.19
+  branch = main
 [submodule "lib/tokenized-strategy"]
 	path = lib/tokenized-strategy
 	url = https://github.com/yearn/tokenized-strategy

--- a/contracts/EverlongStrategy.sol
+++ b/contracts/EverlongStrategy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.22;
+pragma solidity 0.8.24;
 
 import { IHyperdrive } from "hyperdrive/contracts/src/interfaces/IHyperdrive.sol";
 import { FixedPointMath } from "hyperdrive/contracts/src/libraries/FixedPointMath.sol";
@@ -75,6 +75,24 @@ contract EverlongStrategy is BaseStrategy {
     using SafeCast for *;
     using SafeERC20 for ERC20;
 
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                        Transient Storage Slots                        │
+    // ╰───────────────────────────────────────────────────────────────────────╯
+
+    string constant TEND_ENABLED_SLOT_KEY = "TEND_ENABLED";
+
+    string constant MIN_OUTPUT_SLOT_KEY = "MIN_OUTPUT";
+
+    string constant MIN_VAULT_SHARE_PRICE_SLOT_KEY = "MIN_VAULT_SHARE_PRICE";
+
+    string constant POSITION_CLOSURE_LIMIT_SLOT_KEY = "POSITION_CLOSURE_LIMIT";
+
+    string constant EXTRA_DATA_SLOT_KEY = "EXTRA_DATA";
+
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                       Constants and Immutables                        │
+    // ╰───────────────────────────────────────────────────────────────────────╯
+
     /// @notice Amount of additional bonds to close during a partial position
     ///         closure to avoid rounding errors. Represented as a percentage
     ///         of the positions total  amount of bonds where 1e18 represents
@@ -101,11 +119,16 @@ contract EverlongStrategy is BaseStrategy {
     // │                                 State                                 │
     // ╰───────────────────────────────────────────────────────────────────────╯
 
-    /// @dev Configuration for how `_tend(..)` is performed.
-    IEverlongStrategy.TendConfig internal _tendConfig;
-
     /// @dev Structure to store and account for everlong-controlled positions.
     Portfolio.State internal _portfolio;
+
+    /// @dev Mapping to store valid depositors. Used to limit interactions with
+    ///      this strategy to only approved vaults.
+    ///
+    /// @dev Depositors are restricted since this strategy is intended to be
+    ///      deployed with a `profitMaxUnlockTime` of zero which is manipulable
+    ///      if non-vaults are allowed to interact.
+    mapping(address => bool) internal _depositors;
 
     // ╭───────────────────────────────────────────────────────────────────────╮
     // │                              Constructor                              │
@@ -125,6 +148,20 @@ contract EverlongStrategy is BaseStrategy {
         hyperdrive = _hyperdrive;
         asBase = _asBase;
         _poolConfig = IHyperdrive(_hyperdrive).getPoolConfig();
+    }
+
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                             Permissioning                             │
+    // ╰───────────────────────────────────────────────────────────────────────╯
+
+    /// @notice Enable or disable deposits to the strategy `_depositor`.
+    /// @dev Can only be called by the strategy's `Management` address.
+    /// @param _depositor Address to enable/disable deposits for.
+    function setDepositor(
+        address _depositor,
+        bool _enabled
+    ) external onlyManagement {
+        _depositors[_depositor] = _enabled;
     }
 
     // ╭───────────────────────────────────────────────────────────────────────╮
@@ -223,12 +260,27 @@ contract EverlongStrategy is BaseStrategy {
             asset.balanceOf(address(this));
     }
 
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                              Maintenance                              │
+    // ╰───────────────────────────────────────────────────────────────────────╯
+
     /// @dev Can be called inbetween reports to rebalance the portfolio.
     /// @param _totalIdle The current amount of idle funds that are available to
     ///         deploy.
     function _tend(uint256 _totalIdle) internal override {
+        // Read the TendConfig from transient storage.
+        (
+            bool tendEnabled,
+            IEverlongStrategy.TendConfig memory tendConfig
+        ) = getTendConfig();
+
+        // If TendConfig hasn't been set, don't run the tend.
+        if (!tendEnabled) {
+            return;
+        }
+
         // Close matured positions.
-        _totalIdle += _closeMaturedPositions(_tendConfig.positionClosureLimit);
+        _totalIdle += _closeMaturedPositions(tendConfig.positionClosureLimit);
 
         // Limit the amount that can be spent by the deposit limit.
         uint256 toSpend = _totalIdle.min(availableDepositLimit(address(this)));
@@ -241,9 +293,9 @@ contract EverlongStrategy is BaseStrategy {
                 .openLong(
                     asBase,
                     toSpend,
-                    _tendConfig.minOutput,
-                    _tendConfig.minVaultSharePrice,
-                    _tendConfig.extraData
+                    tendConfig.minOutput,
+                    tendConfig.minVaultSharePrice,
+                    tendConfig.extraData
                 );
 
             // Account for the new position in the portfolio.
@@ -257,6 +309,90 @@ contract EverlongStrategy is BaseStrategy {
     /// @return Return true if tend() should be called by keeper, false if not.
     function _tendTrigger() internal view override returns (bool) {
         return hasMaturedPositions() || canOpenPosition();
+    }
+
+    /// @notice Sets the temporary tend configuration. Will only persist through
+    ///         the duration of the transaction. Must be called in the same tx
+    ///         as `tend()`.
+    function setTendConfig(
+        IEverlongStrategy.TendConfig memory _config
+    ) external onlyKeepers {
+        // HACK: Must hash these every time since only direct number constants
+        //       are supported by inline assembly.
+        //
+        // Calculate the slots where each part of the `TendConfig` are stored.
+        bytes32 tendEnabledSlot = keccak256(bytes(TEND_ENABLED_SLOT_KEY));
+        bytes32 minOutputSlot = keccak256(bytes(MIN_OUTPUT_SLOT_KEY));
+        bytes32 minVaultSharePriceSlot = keccak256(
+            bytes(MIN_VAULT_SHARE_PRICE_SLOT_KEY)
+        );
+        bytes32 positionClosureLimitSlot = keccak256(
+            bytes(POSITION_CLOSURE_LIMIT_SLOT_KEY)
+        );
+        bytes32 extraDataSlot = keccak256(bytes(EXTRA_DATA_SLOT_KEY));
+
+        // Set the flag indicating that TendConfig has been set.
+        // Store each part of the TendConfig in transient storage.
+        uint256 minOutput = _config.minOutput;
+        uint256 minVaultSharePrice = _config.minVaultSharePrice;
+        uint256 positionClosureLimit = _config.positionClosureLimit;
+        bytes memory extraData = _config.extraData;
+        assembly {
+            tstore(tendEnabledSlot, 1)
+            tstore(minOutputSlot, minOutput)
+            tstore(minVaultSharePriceSlot, minVaultSharePrice)
+            tstore(positionClosureLimitSlot, positionClosureLimit)
+            tstore(extraDataSlot, extraData)
+        }
+    }
+
+    /// @notice Reads and returns the current tend configuration from transient
+    ///         storage.
+    /// @return tendEnabled Whether or not TendConfig has been set.
+    /// @return . The current tend configuration.
+    function getTendConfig()
+        public
+        view
+        returns (bool tendEnabled, IEverlongStrategy.TendConfig memory)
+    {
+        // HACK: Must hash these every time since only direct number constants
+        //       are supported by inline assembly.
+        //
+        // Calculate the slots where each part of the `TendConfig` are stored.
+        bytes32 tendEnabledSlot = keccak256(bytes(TEND_ENABLED_SLOT_KEY));
+        bytes32 minOutputSlot = keccak256(bytes(MIN_OUTPUT_SLOT_KEY));
+        bytes32 minVaultSharePriceSlot = keccak256(
+            bytes(MIN_VAULT_SHARE_PRICE_SLOT_KEY)
+        );
+        bytes32 positionClosureLimitSlot = keccak256(
+            bytes(POSITION_CLOSURE_LIMIT_SLOT_KEY)
+        );
+
+        // Load each part of the TendConfig from transient storage.
+        // If the TendConfig hasn't been set, revert.
+        bytes32 extraDataSlot = keccak256(bytes(EXTRA_DATA_SLOT_KEY));
+        uint256 minOutput;
+        uint256 minVaultSharePrice;
+        uint256 positionClosureLimit;
+        bytes memory extraData;
+        assembly {
+            tendEnabled := tload(tendEnabledSlot)
+            minOutput := tload(minOutputSlot)
+            minVaultSharePrice := tload(minVaultSharePriceSlot)
+            positionClosureLimit := tload(positionClosureLimitSlot)
+            extraData := tload(extraDataSlot)
+        }
+
+        // Return the TendConfig.
+        return (
+            tendEnabled,
+            IEverlongStrategy.TendConfig({
+                minOutput: minOutput,
+                minVaultSharePrice: minVaultSharePrice,
+                positionClosureLimit: positionClosureLimit,
+                extraData: extraData
+            })
+        );
     }
 
     // ╭───────────────────────────────────────────────────────────────────────╮
@@ -390,55 +526,24 @@ contract EverlongStrategy is BaseStrategy {
     }
 
     // ╭───────────────────────────────────────────────────────────────────────╮
-    // │                                Setters                                │
-    // ╰───────────────────────────────────────────────────────────────────────╯
-
-    /// @notice Sets the minimum number of bonds to receive when opening a long.
-    /// @param _minOutput Minimum number of bonds to receive when opening a
-    ///        long.
-    function setMinOutput(uint256 _minOutput) external onlyKeepers {
-        _tendConfig.minOutput = _minOutput;
-    }
-
-    /// @notice Sets the minimum vault share price when opening a long.
-    /// @param _minVaultSharePrice Minimum vault share price when opening a
-    ///        long.
-    function setMinVaultSharePrice(
-        uint256 _minVaultSharePrice
-    ) external onlyKeepers {
-        _tendConfig.minVaultSharePrice = _minVaultSharePrice;
-    }
-
-    /// @notice Sets the max amount of mature positions to close at a time.
-    /// @param _positionClosureLimit Max amount of mature positions to close at
-    ///        a time.
-    function setPositionClosureLimit(
-        uint256 _positionClosureLimit
-    ) external onlyKeepers {
-        _tendConfig.positionClosureLimit = _positionClosureLimit;
-    }
-
-    /// @notice Sets the extra data to pass to hyperdrive when opening/closing
-    ///         longs.
-    /// @param _extraData Extra data to pass to hyperdrive when opening/closing
-    ///         longs.
-    function setExtraData(bytes memory _extraData) external onlyKeepers {
-        _tendConfig.extraData = _extraData;
-    }
-
-    // ╭───────────────────────────────────────────────────────────────────────╮
     // │                                 Views                                 │
     // ╰───────────────────────────────────────────────────────────────────────╯
 
     /// @notice Gets the max amount of `asset` that an address can deposit.
-    /// @param . The address that is depositing into the strategy.
-    /// @return The available amount the `_owner` can deposit in terms of
+    /// @dev Only pre-approved addresses (vaults) are able to deposit.
+    /// @param _depositor The address that is depositing into the strategy.
+    /// @return The available amount the `_depositor` can deposit in terms of
     ///         `asset`.
     function availableDepositLimit(
-        address
+        address _depositor
     ) public view override returns (uint256) {
-        // Limit deposits to the maximum long that can be opened in hyperdrive.
-        return IHyperdrive(hyperdrive).calculateMaxLong();
+        // Only pre-approved addresses are able to deposit.
+        if (_depositors[_depositor] || _depositor == address(this)) {
+            // Limit deposits to the maximum long that can be opened in hyperdrive.
+            return IHyperdrive(hyperdrive).calculateMaxLong();
+        }
+        // Address has not been pre-approved, return 0.
+        return 0;
     }
 
     /// @notice Weighted average maturity timestamp of the portfolio.
@@ -475,31 +580,6 @@ contract EverlongStrategy is BaseStrategy {
         return
             asset.balanceOf(address(this)) >
             _poolConfig.minimumTransactionAmount;
-    }
-
-    /// @notice Gets the minimum number of bonds to receive when opening a long.
-    /// @return Minimum number of bonds to receive when opening a long.
-    function getMinOutput() external view returns (uint256) {
-        return _tendConfig.minOutput;
-    }
-
-    /// @notice Gets the minimum vault share price when opening a long.
-    /// @return Minimum vault share price when opening a long.
-    function getMinVaultSharePrice() external view returns (uint256) {
-        return _tendConfig.minVaultSharePrice;
-    }
-
-    /// @notice Gets the max amount of mature positions to close at a time.
-    /// @return Max amount of mature positions to close at a time.
-    function getPositionClosureLimit() external view returns (uint256) {
-        return _tendConfig.positionClosureLimit;
-    }
-
-    /// @notice Gets the extra data to pass to hyperdrive when opening/closing
-    ///         longs.
-    /// @return Extra data to pass to hyperdrive when opening/closing longs.
-    function getExtraData() external view returns (bytes memory) {
-        return _tendConfig.extraData;
     }
 
     /// @notice Returns whether the portfolio has matured positions.

--- a/contracts/EverlongStrategyFactory.sol
+++ b/contracts/EverlongStrategyFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-pragma solidity 0.8.22;
+pragma solidity 0.8.24;
 
 import { IEverlongStrategyFactory } from "./interfaces/IEverlongStrategyFactory.sol";
 import { IEverlongStrategy } from "./interfaces/IEverlongStrategy.sol";

--- a/contracts/EverlongStrategyKeeper.sol
+++ b/contracts/EverlongStrategyKeeper.sol
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.24;
+
+import { DebtAllocator } from "vault-periphery/debtAllocators/DebtAllocator.sol";
+import { IHyperdrive } from "hyperdrive/contracts/src/interfaces/IHyperdrive.sol";
+import { FixedPointMath } from "hyperdrive/contracts/src/libraries/FixedPointMath.sol";
+import { SafeCast } from "hyperdrive/contracts/src/libraries/SafeCast.sol";
+import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
+import { BaseStrategy, ERC20 } from "tokenized-strategy/BaseStrategy.sol";
+import { IEverlongStrategy } from "./interfaces/IEverlongStrategy.sol";
+import { EVERLONG_STRATEGY_KEEPER_KIND, EVERLONG_VERSION, ONE } from "./libraries/Constants.sol";
+import { HyperdriveExecutionLibrary } from "./libraries/HyperdriveExecution.sol";
+import { Portfolio } from "./libraries/Portfolio.sol";
+import { IRoleManager } from "./interfaces/IRoleManager.sol";
+import { CommonReportTrigger } from "lib/vault-periphery/lib/tokenized-strategy-periphery/src/ReportTrigger/CommonReportTrigger.sol";
+import { IVault } from "yearn-vaults-v3/interfaces/IVault.sol";
+import { Roles } from "yearn-vaults-v3/interfaces/Roles.sol";
+import { Ownable } from "openzeppelin/access/Ownable.sol";
+import { IStrategy } from "tokenized-strategy/interfaces/IStrategy.sol";
+
+/// @author DELV
+/// @title EverlongStrategyKeeper
+/// @notice Periphery contract to simplify operations for keepers.
+/// @custom:disclaimer The language used in this code is for coding convenience
+///                    only, and is not intended to, and does not, have any
+///                    particular legal or regulatory significance.
+contract EverlongStrategyKeeper is Ownable {
+    using FixedPointMath for uint256;
+    using HyperdriveExecutionLibrary for IHyperdrive;
+    using Portfolio for Portfolio.State;
+    using SafeCast for *;
+    using SafeERC20 for ERC20;
+
+    string constant name = "EverlongStrategyKeeper";
+
+    string constant kind = EVERLONG_STRATEGY_KEEPER_KIND;
+
+    string constant version = EVERLONG_VERSION;
+
+    /// @notice Address of the target RoleManager contract.
+    /// @dev Helpful for getting periphery contract addresses and enumerating
+    ///      vaults.
+    address roleManager;
+
+    /// @notice Address of the external `CommonReportTrigger` contract.
+    /// @dev This contract contains default checks for whether to report+tend.
+    address trigger;
+
+    /// @notice Initialize the EverlongStrategyKeeper contract.
+    /// @param _trigger Address for the `CommonReportTrigger` contract.
+    constructor(address _roleManager, address _trigger) Ownable(msg.sender) {
+        roleManager = _roleManager;
+        trigger = _trigger;
+    }
+
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                                Setters                                │
+    // ╰───────────────────────────────────────────────────────────────────────╯
+
+    /// @notice Updates the address of the CommonReportTrigger contract.
+    /// @param _trigger Address of the CommonReportTrigger contract to set.
+    function setTrigger(address _trigger) external onlyOwner {
+        trigger = _trigger;
+    }
+
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                              Maintenance                              │
+    // ╰───────────────────────────────────────────────────────────────────────╯
+
+    /// @notice Calls `process_report()` on the vault/strategy combination if
+    ///      needed.
+    /// @param _vault Address of the vault contract to process the report on.
+    /// @param _strategy Address of the strategy contract to process the report
+    ///        on.
+    function processReport(address _vault, address _strategy) public onlyOwner {
+        // Bail if this contract doesn't have the REPORTING_MANAGER role.
+        uint256 roleMap = IVault(_vault).roles(address(this));
+        if (roleMap & Roles.REPORTING_MANAGER != roleMap) {
+            return;
+        }
+
+        // Check if report should be called on the vault/strategy combination.
+        (
+            bool shouldReportVault,
+            bytes memory vaultCalldataOrReason
+        ) = CommonReportTrigger(trigger).defaultVaultReportTrigger(
+                _vault,
+                _strategy
+            );
+
+        // If process_report should be called, call it with the recommended
+        // parameters.
+        if (shouldReportVault) {
+            (bool success, bytes memory err) = _vault.call(
+                vaultCalldataOrReason
+            );
+            if (!success) {
+                revert(
+                    string.concat("vault process_report failed: ", string(err))
+                );
+            }
+        }
+    }
+
+    /// @dev Calls `report()` on the strategy if needed.
+    ///
+    /// @param _strategy Address of the strategy contract to report on.
+    /// @param _config Configuration for the `tend()` function called within
+    ///        `_harvestAndReport()` in the strategy.
+    function strategyReport(
+        address _strategy,
+        IEverlongStrategy.TendConfig memory _config
+    ) public onlyOwner {
+        // Bail if this contract isn't the keeper.
+        if (IStrategy(_strategy).keeper() != address(this)) {
+            return;
+        }
+
+        // Check if report should be called on the strategy.
+        (
+            bool shouldReportStrategy,
+            bytes memory strategyCalldataOrReason
+        ) = CommonReportTrigger(trigger).defaultStrategyReportTrigger(
+                _strategy
+            );
+
+        // If report should be called, call it with the recommended parameters.
+        if (shouldReportStrategy) {
+            IEverlongStrategy(_strategy).setTendConfig(_config);
+            (bool success, bytes memory err) = _strategy.call(
+                strategyCalldataOrReason
+            );
+            if (!success) {
+                revert(string.concat("strategy report failed: ", string(err)));
+            }
+        }
+    }
+
+    /// @dev Calls `tend()` on the strategy if needed and sets the
+    ///      tend configuration.
+    /// @param _strategy Address of the strategy to tend.
+    /// @param _config Configuration for the tend call.
+    function tend(
+        address _strategy,
+        IEverlongStrategy.TendConfig memory _config
+    ) public onlyOwner {
+        // Bail if this contract isn't the keeper.
+        if (IStrategy(_strategy).keeper() != address(this)) {
+            return;
+        }
+
+        // Check if tend should be called.
+        (bool shouldTend, bytes memory calldataOrReason) = CommonReportTrigger(
+            trigger
+        ).strategyTendTrigger(_strategy);
+
+        // If tend should be called, call it with the recommended parameters.
+        if (shouldTend) {
+            IEverlongStrategy(_strategy).setTendConfig(_config);
+            (bool success, bytes memory err) = _strategy.call(calldataOrReason);
+            if (!success) {
+                revert(string.concat("strategy tend failed: ", string(err)));
+            }
+        }
+    }
+
+    /// @dev Calls `update_debt()` on the vault if needed.
+    /// @param _vault Address of the vault to update debt for.
+    /// @param _strategy Address of the strategy to update debt for.
+    function update_debt(address _vault, address _strategy) public onlyOwner {
+        // Get the DebtAllocator contract address.
+        DebtAllocator debtAllocator = DebtAllocator(
+            IRoleManager(roleManager).getDebtAllocator(_vault)
+        );
+
+        // Bail if there's no DebtAllocator for the vault or this contract isn't
+        // the keeper.
+        if (
+            address(debtAllocator) == address(0) ||
+            !debtAllocator.keepers(address(this))
+        ) {
+            revert("vault update debt failed: improper vault configuration");
+        }
+
+        // If update_debt should be called, call it with the recommended parameters.
+        (bool shouldUpdateDebt, bytes memory calldataOrReason) = debtAllocator
+            .shouldUpdateDebt(_vault, _strategy);
+        if (shouldUpdateDebt) {
+            (bool success, bytes memory err) = address(debtAllocator).call(
+                calldataOrReason
+            );
+            if (!success) {
+                revert(
+                    string.concat("vault update debt failed: ", string(err))
+                );
+            }
+        }
+    }
+}

--- a/contracts/interfaces/IEverlongEvents.sol
+++ b/contracts/interfaces/IEverlongEvents.sol
@@ -2,21 +2,9 @@
 pragma solidity ^0.8.20;
 
 interface IEverlongEvents {
-    // ── Admin ──────────────────────────────────────────────────
-
-    /// @notice Emitted when admin is transferred.
-    event AdminUpdated(address indexed admin);
-
-    // ── Positions ──────────────────────────────────────────────
-
     /// @notice Emitted when a new position is added to the bond portfolio.
-    /// TODO: Reconsider naming https://github.com/delvtech/hyperdrive/pull/1096#discussion_r1681337414
     event PositionOpened(uint128 indexed maturityTime, uint128 bondAmount);
 
     /// @notice Emitted when an existing position is closed.
-    /// TODO: Reconsider naming https://github.com/delvtech/hyperdrive/pull/1096#discussion_r1681337414
     event PositionClosed(uint128 indexed maturityTime, uint128 bondAmount);
-
-    /// @notice Emitted when Everlong's underlying portfolio is rebalanced.
-    event Rebalanced();
 }

--- a/contracts/interfaces/IEverlongStrategy.sol
+++ b/contracts/interfaces/IEverlongStrategy.sol
@@ -31,44 +31,20 @@ interface IEverlongStrategy is IStrategy, IEverlongEvents {
         bytes extraData;
     }
 
-    /// @notice Parameters to specify how a rebalance will be performed.
-    struct RebalanceOptions {
-        /// @notice Limit on the amount of idle to spend on a new position.
-        /// @dev A value of zero indicates no limit.
-        uint256 spendingLimit;
-        /// @notice Minimum amount of bonds to receive when opening a position.
-        uint256 minOutput;
-        /// @notice Minimum vault share price when opening a position.
-        uint256 minVaultSharePrice;
-        /// @notice Maximum amount of mature positions that can be closed.
-        /// @dev A value of zero indicates no limit.
-        uint256 positionClosureLimit;
-        /// @notice Passed to hyperdrive `openLong()` and `closeLong()`.
-        bytes extraData;
-    }
-
     // ╭───────────────────────────────────────────────────────────────────────╮
     // │                                SETTERS                                │
     // ╰───────────────────────────────────────────────────────────────────────╯
 
-    /// @notice Sets the minimum number of bonds to receive when opening a long.
-    /// @param _minOutput Minimum number of bonds to receive when opening a long.
-    function setMinOutput(uint256 _minOutput) external;
+    /// @notice Enable or disable deposits to the strategy `_depositor`.
+    /// @dev Can only be called by the strategy's `Management` address.
+    /// @param _depositor Address to enable/disable deposits for.
+    function setDepositor(address _depositor, bool _enabled) external;
 
-    /// @notice Sets the minimum vault share price when opening a long.
-    /// @param _minVaultSharePrice Minimum vault share price when opening a long.
-    function setMinVaultSharePrice(uint256 _minVaultSharePrice) external;
-
-    /// @notice Sets the max amount of mature positions to close at a time.
-    /// @param _positionClosureLimit Max amount of mature positions to close at
-    ///        a time.
-    function setPositionClosureLimit(uint256 _positionClosureLimit) external;
-
-    /// @notice Sets the extra data to pass to hyperdrive when opening/closing
-    ///         longs.
-    /// @param _extraData Extra data to pass to hyperdrive when opening/closing
-    ///         longs.
-    function setExtraData(bytes memory _extraData) external;
+    /// @notice Sets the temporary tend configuration. Necessary for `tend()`
+    ///         call to succeed. Must be called in the same tx as `tend()`.
+    function setTendConfig(
+        IEverlongStrategy.TendConfig memory _config
+    ) external;
 
     // ╭───────────────────────────────────────────────────────────────────────╮
     // │                                 VIEWS                                 │
@@ -92,22 +68,13 @@ interface IEverlongStrategy is IStrategy, IEverlongEvents {
     /// @return True if a new position can be opened, false otherwise.
     function canOpenPosition() external view returns (bool);
 
-    /// @notice Gets the minimum number of bonds to receive when opening a long.
-    /// @return Minimum number of bonds to receive when opening a long.
-    function getMinOutput() external view returns (uint256);
-
-    /// @notice Gets the minimum vault share price when opening a long.
-    /// @return Minimum vault share price when opening a long.
-    function getMinVaultSharePrice() external view returns (uint256);
-
-    /// @notice Gets the max amount of mature positions to close at a time.
-    /// @return Max amount of mature positions to close at a time.
-    function getPositionClosureLimit() external view returns (uint256);
-
-    /// @notice Gets the extra data to pass to hyperdrive when opening/closing
-    ///         longs.
-    /// @return Extra data to pass to hyperdrive when opening/closing longs.
-    function getExtraData() external view returns (bytes memory);
+    /// @notice Reads and returns the current tend configuration from transient
+    ///         storage.
+    /// @return tendEnabled Whether TendConfig has been set.
+    /// @return The current tend configuration.
+    function getTendConfig()
+        external
+        returns (bool tendEnabled, IEverlongStrategy.TendConfig memory);
 
     /// @notice Determines whether any positions are matured.
     /// @return True if any positions are matured, false otherwise.

--- a/contracts/interfaces/IRoleManager.sol
+++ b/contracts/interfaces/IRoleManager.sol
@@ -4,9 +4,34 @@ pragma solidity ^0.8.20;
 // WARN: Directly importing `RoleManager.sol` from vault-periphery results in
 //       solidity compiler errors, so needed methods are copied here.
 interface IRoleManager {
-    // ╭─────────────────────────────────────────────────────────╮
-    // │ VAULT CREATION                                          │
-    // ╰─────────────────────────────────────────────────────────╯
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                             Position IDs                              │
+    // ╰───────────────────────────────────────────────────────────────────────╯
+
+    /// @notice Position ID for pending governance.
+    function PENDING_GOVERNANCE() external view returns (bytes32);
+
+    /// @notice Position ID for governance.
+    function GOVERNANCE() external view returns (bytes32);
+
+    /// @notice Position ID for management.
+    function MANAGEMENT() external view returns (bytes32);
+
+    /// @notice Position ID for keeper.
+    function KEEPER() external view returns (bytes32);
+
+    /// @notice Position ID for registry.
+    function REGISTRY() external view returns (bytes32);
+
+    /// @notice Position ID for accountant.
+    function ACCOUNTANT() external view returns (bytes32);
+
+    /// @notice Position ID for debt allocator.
+    function DEBT_ALLOCATOR() external view returns (bytes32);
+
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                            Vault Creation                             │
+    // ╰───────────────────────────────────────────────────────────────────────╯
 
     /**
      * @notice Creates a new endorsed vault with default profit max unlock time.
@@ -115,9 +140,9 @@ interface IRoleManager {
         uint256 _role
     ) external;
 
-    // ╭─────────────────────────────────────────────────────────╮
-    // │ SETTERS                                                 │
-    // ╰─────────────────────────────────────────────────────────╯
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                                Setters                                │
+    // ╰───────────────────────────────────────────────────────────────────────╯
 
     /**
      * @notice Setter function for updating a positions roles.
@@ -149,9 +174,9 @@ interface IRoleManager {
      */
     function acceptGovernance() external;
 
-    // ╭─────────────────────────────────────────────────────────╮
-    // │ VIEW METHODS                                            │
-    // ╰─────────────────────────────────────────────────────────╯
+    // ╭───────────────────────────────────────────────────────────────────────╮
+    // │                                 Views                                 │
+    // ╰───────────────────────────────────────────────────────────────────────╯
 
     /**
      * @notice Get the name of this contract.

--- a/contracts/libraries/Constants.sol
+++ b/contracts/libraries/Constants.sol
@@ -8,3 +8,5 @@ string constant EVERLONG_VERSION = "v0.0.1";
 string constant EVERLONG_STRATEGY_KIND = "EverlongStrategy";
 
 string constant EVERLONG_STRATEGY_FACTORY_KIND = "EverlongStrategyFactory";
+
+string constant EVERLONG_STRATEGY_KEEPER_KIND = "EverlongStrategyKeeper";

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-solc_version = '0.8.22'
+solc_version = '0.8.24'
 # The source directory
 src = "contracts"
 # The artifact directory
@@ -27,15 +27,14 @@ gas_limit = "18446744073709551615"
 # allows the ffi to be used
 ffi = true
 # strict warnings
-# TODO: Reenable
-# deny_warnings = true
+deny_warnings = true
 # optimizer settings
 optimizer = true
 optimizer_runs = 10000000 # 10 million runs
 via_ir = false
 # Enable gas-reporting for all contracts
 gas_reports = ["*"]
-evm_version = "paris"
+evm_version = "cancun"
 
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"

--- a/test/integration/PartialClosures.t.sol
+++ b/test/integration/PartialClosures.t.sol
@@ -37,11 +37,11 @@ contract TestPartialClosures is EverlongTest {
             aliceShares.mulDown(0.05e18),
             aliceShares.mulDown(0.95e18)
         );
-        redeemStrategy(_redemptionAmount, alice, false);
+        redeemStrategy(_redemptionAmount, alice, true);
         uint256 positionBondsAfterRedeem = strategy.totalBonds();
 
         // Ensure Everlong still has a position open.
-        assertEq(strategy.positionCount(), 1);
+        assertGt(strategy.positionCount(), 0);
 
         // Ensure the remaining Everlong position has proportionally less bonds
         // than it did prior to redemption.

--- a/test/units/EverlongStrategyFactory.t.sol
+++ b/test/units/EverlongStrategyFactory.t.sol
@@ -21,12 +21,12 @@ contract TestEverlongStrategyFactory is EverlongTest {
     /// @dev Tests that setAddresses succeeds when called by management.
     function test_setAddresses_success() external {
         // Generate some addresses.
-        address management = createUser("management1");
-        address performanceFeeRecipient = createUser(
+        (address management, ) = createUser("management1");
+        (address performanceFeeRecipient, ) = createUser(
             "performanceFeeRecipient1"
         );
-        address keeper = createUser("keeper1");
-        address emergencyAdmin = createUser("emergencyAdmin1");
+        (address keeper, ) = createUser("keeper1");
+        (address emergencyAdmin, ) = createUser("emergencyAdmin1");
 
         // Call setAddresses as the management with new addresses.
         vm.prank(strategyFactory.management());
@@ -50,12 +50,12 @@ contract TestEverlongStrategyFactory is EverlongTest {
     /// @dev Tests that setAddresses fails when not called by management.
     function test_setAddresses_failure_OnlyManagement() external {
         // Generate some addresses.
-        address management = createUser("management1");
-        address performanceFeeRecipient = createUser(
+        (address management, ) = createUser("management1");
+        (address performanceFeeRecipient, ) = createUser(
             "performanceFeeRecipient1"
         );
-        address keeper = createUser("keeper1");
-        address emergencyAdmin = createUser("emergencyAdmin1");
+        (address keeper, ) = createUser("keeper1");
+        (address emergencyAdmin, ) = createUser("emergencyAdmin1");
 
         // Call setAddresses as a non-management.
         // The call should revert with 'OnlyManagement'.
@@ -138,10 +138,12 @@ contract TestEverlongStrategyFactory is EverlongTest {
     function test_isDeployedStrategy_failure() external {
         // Generate some addresses.
         string memory name = "TestingEverlongStrategyFactory";
-        address management = createUser("management");
-        address performanceFeeRecipient = createUser("performanceFeeRecipient");
-        address keeper = createUser("keeper");
-        address emergencyAdmin = createUser("emergencyAdmin");
+        (address management, ) = createUser("management1");
+        (address performanceFeeRecipient, ) = createUser(
+            "performanceFeeRecipient1"
+        );
+        (address keeper, ) = createUser("keeper1");
+        (address emergencyAdmin, ) = createUser("emergencyAdmin1");
 
         // Deploy the factory.
         strategyFactory = new EverlongStrategyFactory(
@@ -160,10 +162,12 @@ contract TestEverlongStrategyFactory is EverlongTest {
     function test_constructor_success() external {
         // Generate some addresses.
         string memory name = "TestingEverlongStrategyFactory";
-        address management = createUser("management");
-        address performanceFeeRecipient = createUser("performanceFeeRecipient");
-        address keeper = createUser("keeper");
-        address emergencyAdmin = createUser("emergencyAdmin");
+        (address management, ) = createUser("management1");
+        (address performanceFeeRecipient, ) = createUser(
+            "performanceFeeRecipient1"
+        );
+        (address keeper, ) = createUser("keeper1");
+        (address emergencyAdmin, ) = createUser("emergencyAdmin1");
 
         // Deploy the factory.
         strategyFactory = new EverlongStrategyFactory(


### PR DESCRIPTION
- Also disables `auto_allocate` since it does not respect DebtAllocator configuration for idle liquidity