### PR TITLE
vault shares token testing + misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ source .env && \
   STRATEGY_NAME='<name_of_a_deployed_strategy>' \
   NAME='<your_vault>' \
   SYMBOL='<your_vault_symbol>' \
+  CATEGORY=<your_category_number> \
   forge script script/DeployVault.s.sol --rpc-url 0.0.0.0:8545 --broadcast
 ```
 

--- a/contracts/EverlongStrategyKeeper.sol
+++ b/contracts/EverlongStrategyKeeper.sol
@@ -33,22 +33,22 @@ contract EverlongStrategyKeeper is Ownable {
     using SafeERC20 for ERC20;
 
     /// @notice Kind of the EverlongStrategyKeeper.
-    string constant kind = EVERLONG_STRATEGY_KEEPER_KIND;
+    string public constant kind = EVERLONG_STRATEGY_KEEPER_KIND;
 
     /// @notice Version of the EverlongStrategyKeeper.
-    string constant version = EVERLONG_VERSION;
+    string public constant version = EVERLONG_VERSION;
 
     /// @notice Name of the EverlongStrategyKeeper.
-    string name;
+    string public name;
 
     /// @notice Address of the target RoleManager contract.
     /// @dev Helpful for getting periphery contract addresses and enumerating
     ///      vaults.
-    address roleManager;
+    address public roleManager;
 
     /// @notice Address of the external `CommonReportTrigger` contract.
     /// @dev This contract contains default checks for whether to report+tend.
-    address trigger;
+    address public trigger;
 
     /// @notice Initialize the EverlongStrategyKeeper contract.
     /// @param _name Name for the keeper contract.

--- a/contracts/libraries/Constants.sol
+++ b/contracts/libraries/Constants.sol
@@ -7,6 +7,24 @@ uint256 constant ONE = 1e18;
 /// @dev Maximum basis points value (10_000 == 100%).
 uint256 constant MAX_BPS = 10_000;
 
+/// @dev We can assume that almost all Hyperdrive deployments have the
+///      `convertToBase` and `convertToShares` functions, but there is
+///      one legacy sDAI pool that was deployed before these functions
+///      were written. We explicitly special case conversions for this
+///      pool.
+address constant LEGACY_SDAI_HYPERDRIVE = address(
+    0x324395D5d835F84a02A75Aa26814f6fD22F25698
+);
+
+/// @dev We can assume that almost all Hyperdrive deployments have the
+///      `convertToBase` and `convertToShares` functions, but there is
+///      one legacy stETH pool that was deployed before these functions
+///      were written. We explicitly special case conversions for this
+///      pool.
+address constant LEGACY_STETH_HYPERDRIVE = address(
+    0xd7e470043241C10970953Bd8374ee6238e77D735
+);
+
 /// @dev Yearn RoleManagerFactory address for mainnet, base, and arbitrum.
 address constant ROLE_MANAGER_FACTORY_ADDRESS = 0xca12459a931643BF28388c67639b3F352fe9e5Ce;
 

--- a/script/DeployVault.s.sol
+++ b/script/DeployVault.s.sol
@@ -33,6 +33,14 @@ contract DeployVault is BaseDeployScript {
     // ╭───────────────────────────────────────────────────────────────────────╮
     // │                          Optional Arguments                           │
     // ╰───────────────────────────────────────────────────────────────────────╯
+
+    /// @dev Category for the vault.
+    /// @dev Yearn docs state that vaults with a category of 0 are arbitrary,
+    ///      however a category of 1 indicates lowest risk. Whatever method we
+    ///      choose, let's try to be consistent.
+    uint256 internal CATEGORY;
+    uint256 internal CATEGORY_DEFAULT = 0;
+
     /// @dev ProfitMaxUnlock for the vault. Should be the same interval that the
     ///      underlying yield source accrues on.
     uint256 internal PROFIT_MAX_UNLOCK;
@@ -120,6 +128,7 @@ contract DeployVault is BaseDeployScript {
             : "";
 
         // Read optional arguments.
+        CATEGORY = vm.envOr("CATEGORY", CATEGORY_DEFAULT);
         PROFIT_MAX_UNLOCK = vm.envOr(
             "PROFIT_MAX_UNLOCK",
             PROFIT_MAX_UNLOCK_DEFAULT
@@ -172,7 +181,7 @@ contract DeployVault is BaseDeployScript {
         IVault vault = IVault(
             IRoleManager(roleManagerAddress).newVault(
                 IStrategy(strategyAddress).asset(),
-                0,
+                CATEGORY,
                 output.name,
                 output.symbol
             )

--- a/test/VaultTest.sol
+++ b/test/VaultTest.sol
@@ -192,7 +192,6 @@ abstract contract VaultTest is HyperdriveTest {
             HYPERDRIVE_INITIALIZER = deployer;
         }
         initialize(HYPERDRIVE_INITIALIZER, FIXED_RATE, INITIAL_CONTRIBUTION);
-        advanceTimeWithCheckpoints(1);
 
         vm.stopPrank();
     }

--- a/test/everlong/EverlongTest.sol
+++ b/test/everlong/EverlongTest.sol
@@ -92,6 +92,9 @@ contract EverlongTest is VaultTest, IEverlongEvents {
         strategy.setEmergencyAdmin(emergencyAdmin);
         vm.stopPrank();
 
+        // Set the appropriate asset.
+        asset = IERC20(hyperdrive.baseToken());
+
         // As the `management` address:
         //   1. Accept the `management` role for the strategy.
         //   2. Set the `profitMaxUnlockTime` to zero.
@@ -105,28 +108,12 @@ contract EverlongTest is VaultTest, IEverlongEvents {
     /// @dev Deploy the Everlong Yearn v3 Vault.
     function setUpEverlongVault() internal {
         // As the `governance` address:
-        //   1. Accept the "Fee Manager" role for the Accountant.
-        //   2. Set the default `config.maxLoss` for the accountant to be 10%.
-        //      This will enable losses of up to 10% across reports before
-        //      reverting.
-        //   3. Deploy the Vault using the RoleManager.
-        //   4. Add the EverlongStrategy to the vault.
-        //   5. Update the max debt for the strategy to be the maximum uint256.
-        //   6. Configure the vault to `auto_allocate` which will automatically
+        //   1. Deploy the Vault using the RoleManager.
+        //   2. Add the EverlongStrategy to the vault.
+        //   3. Update the max debt for the strategy to be the maximum uint256.
+        //   4. Configure the vault to `auto_allocate` which will automatically
         //      update the strategy's debt on deposit.
         vm.startPrank(governance);
-        accountant.acceptFeeManager();
-        IAccountant.Fee memory defaultConfig = accountant.defaultConfig();
-        // Must increase the accountant maxLoss for reporting since `totalAssets`
-        // decreases whenever opening longs.
-        accountant.updateDefaultConfig(
-            0,
-            0,
-            0,
-            0,
-            defaultConfig.maxGain,
-            defaultConfig.maxLoss
-        );
         vault = IVault(
             roleManager.newVault(
                 address(asset),

--- a/test/everlong/integration/SDAIVaultSharesToken.t.sol
+++ b/test/everlong/integration/SDAIVaultSharesToken.t.sol
@@ -33,7 +33,7 @@ contract TestSDAIVaultSharesToken is EverlongTest {
 
     /// @dev Deposit into the SDAI everlong vault.
     /// @param _assets Amount of assets to deposit.
-    /// @param _to Source of the tokens.
+    /// @param _from Source of the tokens.
     /// @return shares Amount of shares received from the deposit.
     function depositSDAI(
         uint256 _assets,
@@ -47,9 +47,9 @@ contract TestSDAIVaultSharesToken is EverlongTest {
     }
 
     /// @dev Redeem shares from the SDAI everlong vault.
-    /// @param _assets Amount of shares to redeem.
-    /// @param _to Source of the shares.
-    /// @return shares Amount of assets received from the redemption.
+    /// @param _shares Amount of shares to redeem.
+    /// @param _from Source of the shares.
+    /// @return assets Amount of assets received from the redemption.
     function redeemSDAI(
         uint256 _shares,
         address _from

--- a/test/everlong/integration/SDAIVaultSharesToken.t.sol
+++ b/test/everlong/integration/SDAIVaultSharesToken.t.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.20;
+
+import { console2 as console } from "forge-std/console2.sol";
+import { IERC20, IHyperdrive } from "hyperdrive/contracts/src/interfaces/IHyperdrive.sol";
+import { FixedPointMath } from "hyperdrive/contracts/src/libraries/FixedPointMath.sol";
+import { Lib } from "hyperdrive/test/utils/Lib.sol";
+import { IVault } from "yearn-vaults-v3/interfaces/IVault.sol";
+import { IPermissionedStrategy } from "../../../contracts/interfaces/IPermissionedStrategy.sol";
+import { MAX_BPS } from "../../../contracts/libraries/Constants.sol";
+import { HyperdriveExecutionLibrary } from "../../../contracts/libraries/HyperdriveExecution.sol";
+import { EverlongStrategy } from "../../../contracts/EverlongStrategy.sol";
+import { EverlongTest } from "../EverlongTest.sol";
+
+/// @dev Test ensuring that Everlong works with sDAI Hyperdrive and
+///      AS_BASE=false.
+contract TestSDAIVaultSharesToken is EverlongTest {
+    using FixedPointMath for *;
+    using Lib for *;
+    using HyperdriveExecutionLibrary for *;
+
+    /// @dev SDAI whale account used for easy token minting.
+    address WHALE = 0x0740c011A4160139Bd2E4EA091581d35ee3454da;
+
+    /// @dev "Mint" tokens to an account by transferring from the whale.
+    /// @param _amount Amount of tokens to "mint".
+    /// @param _to Destination for the tokens.
+    function mintAsset(uint256 _amount, address _to) internal {
+        vm.startPrank(WHALE);
+        asset.transfer(_to, _amount);
+        vm.stopPrank();
+    }
+
+    /// @dev Deposit into the SDAI everlong vault.
+    /// @param _assets Amount of assets to deposit.
+    /// @param _to Source of the tokens.
+    /// @return shares Amount of shares received from the deposit.
+    function depositSDAI(
+        uint256 _assets,
+        address _from
+    ) internal returns (uint256 shares) {
+        mintAsset(_assets, _from);
+        vm.startPrank(_from);
+        asset.approve(address(vault), _assets);
+        shares = vault.deposit(_assets, _from);
+        vm.stopPrank();
+    }
+
+    /// @dev Redeem shares from the SDAI everlong vault.
+    /// @param _assets Amount of shares to redeem.
+    /// @param _to Source of the shares.
+    /// @return shares Amount of assets received from the redemption.
+    function redeemSDAI(
+        uint256 _shares,
+        address _from
+    ) internal returns (uint256 assets) {
+        vm.startPrank(_from);
+        assets = vault.redeem(_shares, _from, _from);
+        vm.stopPrank();
+    }
+
+    /// @dev Deploy a strategy pointing to the sDAI hyperdrive instance and
+    ///      create a vault around it.
+    function setUp() public virtual override {
+        super.setUp();
+
+        // sDai Hyperdrive mainnet address.
+        hyperdrive = IHyperdrive(0x324395D5d835F84a02A75Aa26814f6fD22F25698);
+
+        // Set the correct asset.
+        asset = IERC20(hyperdrive.vaultSharesToken());
+
+        vm.startPrank(deployer);
+
+        // Deploy and configure the strategy.
+        strategy = IPermissionedStrategy(
+            address(
+                new EverlongStrategy(
+                    address(asset),
+                    "sDAI Strategy",
+                    address(hyperdrive),
+                    false
+                )
+            )
+        );
+        strategy.setPerformanceFeeRecipient(governance);
+        strategy.setKeeper(address(keeperContract));
+        strategy.setPendingManagement(management);
+        strategy.setEmergencyAdmin(emergencyAdmin);
+
+        // Issue the deployer a bunch of stETH... this makes it easy to dish
+        // out to other users later.
+        // uint256 deployerETH = 1_000e18;
+        // deal(deployer, deployerETH);
+        // ILido(address(asset)).submit{ value: deployerETH }(deployer);
+
+        vm.stopPrank();
+
+        // As the `management` address:
+        //   1. Accept the `management` role for the strategy.
+        //   2. Set the `profitMaxUnlockTime` to zero.
+        vm.startPrank(management);
+        strategy.acceptManagement();
+        strategy.setProfitMaxUnlockTime(STRATEGY_PROFIT_MAX_UNLOCK_TIME);
+        strategy.setPerformanceFee(0);
+        vm.stopPrank();
+
+        // As the `governance` address:
+        //   1. Deploy the Vault using the RoleManager.
+        //   2. Add the EverlongStrategy to the vault.
+        //   3. Update the max debt for the strategy to be the maximum uint256.
+        //   4. Configure the vault to `auto_allocate` which will automatically
+        //      update the strategy's debt on deposit.
+        vm.startPrank(governance);
+        vault = IVault(
+            roleManager.newVault(
+                address(asset),
+                0,
+                EVERLONG_NAME,
+                EVERLONG_SYMBOL
+            )
+        );
+        vault.add_strategy(address(strategy));
+        vault.update_max_debt_for_strategy(
+            address(strategy),
+            type(uint256).max
+        );
+        roleManager.setPositionHolder(
+            roleManager.KEEPER(),
+            address(keeperContract)
+        );
+        vm.stopPrank();
+
+        // As the `management` address, configure the DebtAllocator to not
+        // wait to update a strategy's debt and set the minimum change before
+        // updating to just above hyperdrive's minimum transaction amount.
+        vm.startPrank(management);
+        // Set the vault's duration for unlocking profit.
+        vault.setProfitMaxUnlockTime(VAULT_PROFIT_MAX_UNLOCK_TIME);
+        // Enable deposits to the strategy from the vault.
+        strategy.setDepositor(address(vault), true);
+        // Give the `EverlongStrategyKeeper` role to the keeper address.
+        debtAllocator.setKeeper(address(keeperContract), true);
+        // Set minimum wait time for updating strategy debt.
+        debtAllocator.setMinimumWait(0);
+        // Set minimum change in debt for triggering an update.
+        debtAllocator.setMinimumChange(
+            address(vault),
+            MINIMUM_TRANSACTION_AMOUNT + 1
+        );
+        debtAllocator.setStrategyDebtRatio(
+            address(vault),
+            address(strategy),
+            MAX_BPS - TARGET_IDLE_LIQUIDITY_BASIS_POINTS,
+            MAX_BPS - MIN_IDLE_LIQUIDITY_BASIS_POINTS
+        );
+        vm.stopPrank();
+    }
+
+    /// @dev Ensure the deposit functions work as expected.
+    function test_deposit() external {
+        // Alice and Bob deposit into the vault.
+        uint256 depositAmount = 100e18;
+        uint256 aliceShares = depositSDAI(depositAmount, alice);
+        uint256 bobShares = depositSDAI(depositAmount, bob);
+
+        // Alice and Bob should have non-zero share amounts.
+        assertGt(aliceShares, 0);
+        assertGt(bobShares, 0);
+    }
+
+    /// @dev Ensure the rebalance and redeem functions work as expected.
+    function test_redeem() external {
+        // Alice and Bob deposit into the vault.
+        uint256 depositAmount = 100e18;
+        uint256 aliceShares = depositSDAI(depositAmount, alice);
+        uint256 bobShares = depositSDAI(depositAmount, bob);
+
+        // The vault allocates funds to the strategy.
+        rebalance();
+
+        // Alice and Bob redeem their shares from the vault.
+        uint256 aliceRedeemAssets = redeemSDAI(aliceShares, alice);
+        uint256 bobRedeemAssets = redeemSDAI(bobShares, bob);
+
+        // Neither Alice nor Bob should have more assets than they began with.
+        assertLe(aliceRedeemAssets, depositAmount);
+        assertLe(bobRedeemAssets, depositAmount);
+    }
+}

--- a/test/everlong/units/HyperdriveExecution.t.sol
+++ b/test/everlong/units/HyperdriveExecution.t.sol
@@ -197,14 +197,15 @@ contract TestHyperdriveExecution is EverlongTest {
         // Deploy Hyperdrive.
         fixedRate = fixedRate.normalizeToRange(0.001e18, 0.5e18);
         FIXED_RATE = fixedRate;
+        deploy(alice, fixedRate, 0, 0, 0, 0);
         contribution = contribution.normalizeToRange(1_000e18, 500_000_000e18);
         INITIAL_CONTRIBUTION = contribution;
-        super.setUp();
+        initialize(alice, fixedRate, contribution);
 
         // Open a long position that will be held for an entire term. This will
         // decrease the value of the share adjustment to a non-trivial value.
         matureLongAmount = matureLongAmount.normalizeToRange(
-            MINIMUM_TRANSACTION_AMOUNT,
+            MINIMUM_TRANSACTION_AMOUNT + 1,
             hyperdrive.calculateMaxLong() / 2
         );
         openLong(alice, matureLongAmount);
@@ -234,9 +235,10 @@ contract TestHyperdriveExecution is EverlongTest {
         // Deploy Hyperdrive.
         fixedRate = fixedRate.normalizeToRange(0.001e18, 0.5e18);
         FIXED_RATE = fixedRate;
+        deploy(alice, fixedRate, 0, 0, 0, 0);
         contribution = contribution.normalizeToRange(1_000e18, 500_000_000e18);
         INITIAL_CONTRIBUTION = contribution;
-        super.setUp();
+        initialize(alice, fixedRate, contribution);
 
         // Open a short position that will be held for an entire term. This will
         // increase the value of the share adjustment to a non-trivial value.
@@ -313,9 +315,10 @@ contract TestHyperdriveExecution is EverlongTest {
         // Deploy Hyperdrive.
         fixedRate = fixedRate.normalizeToRange(0.001e18, 0.5e18);
         FIXED_RATE = fixedRate;
+        deploy(alice, fixedRate, 0, 0, 0, 0);
         contribution = contribution.normalizeToRange(1_000e18, 500_000_000e18);
         INITIAL_CONTRIBUTION = contribution;
-        super.setUp();
+        initialize(alice, fixedRate, contribution);
 
         // Ensure that the max long is actually the max long.
         _verifyMaxLong(
@@ -339,12 +342,12 @@ contract TestHyperdriveExecution is EverlongTest {
         // Open a long and a short. This sets the long buffer to a non-trivial
         // value which stress tests the max long function.
         initialLongAmount = initialLongAmount.normalizeToRange(
-            MINIMUM_TRANSACTION_AMOUNT,
+            MINIMUM_TRANSACTION_AMOUNT + 1,
             hyperdrive.calculateMaxLong() / 2
         );
         openLong(bob, initialLongAmount);
         initialShortAmount = initialShortAmount.normalizeToRange(
-            MINIMUM_TRANSACTION_AMOUNT,
+            MINIMUM_TRANSACTION_AMOUNT + 1,
             HyperdriveUtils.calculateMaxShort(hyperdrive) / 2
         );
         openShort(bob, initialShortAmount);
@@ -395,7 +398,7 @@ contract TestHyperdriveExecution is EverlongTest {
         vm.stopPrank();
         vm.startPrank(bob);
         finalLongAmount = finalLongAmount.normalizeToRange(
-            maxLong.mulDown(0.1e18).max(MINIMUM_TRANSACTION_AMOUNT),
+            maxLong.mulDown(0.1e18).max(MINIMUM_TRANSACTION_AMOUNT + 1),
             maxLong.mulDown(1000e18).max(
                 MINIMUM_TRANSACTION_AMOUNT.mulDown(10e18)
             )

--- a/test/everlong/units/HyperdriveExecution.t.sol
+++ b/test/everlong/units/HyperdriveExecution.t.sol
@@ -196,11 +196,10 @@ contract TestHyperdriveExecution is EverlongTest {
     ) external {
         // Deploy Hyperdrive.
         fixedRate = fixedRate.normalizeToRange(0.001e18, 0.5e18);
-        deploy(alice, fixedRate, 0, 0, 0, 0);
-
-        // Initialize the Hyperdrive pool.
+        FIXED_RATE = fixedRate;
         contribution = contribution.normalizeToRange(1_000e18, 500_000_000e18);
-        initialize(alice, fixedRate, contribution);
+        INITIAL_CONTRIBUTION = contribution;
+        super.setUp();
 
         // Open a long position that will be held for an entire term. This will
         // decrease the value of the share adjustment to a non-trivial value.
@@ -234,11 +233,10 @@ contract TestHyperdriveExecution is EverlongTest {
     ) external {
         // Deploy Hyperdrive.
         fixedRate = fixedRate.normalizeToRange(0.001e18, 0.5e18);
-        deploy(alice, fixedRate, 0, 0, 0, 0);
-
-        // Initialize the Hyperdrive pool.
+        FIXED_RATE = fixedRate;
         contribution = contribution.normalizeToRange(1_000e18, 500_000_000e18);
-        initialize(alice, fixedRate, contribution);
+        INITIAL_CONTRIBUTION = contribution;
+        super.setUp();
 
         // Open a short position that will be held for an entire term. This will
         // increase the value of the share adjustment to a non-trivial value.
@@ -314,11 +312,10 @@ contract TestHyperdriveExecution is EverlongTest {
     ) internal {
         // Deploy Hyperdrive.
         fixedRate = fixedRate.normalizeToRange(0.001e18, 0.5e18);
-        deploy(alice, fixedRate, 0, 0, 0, 0);
-
-        // Initialize the Hyperdrive pool.
+        FIXED_RATE = fixedRate;
         contribution = contribution.normalizeToRange(1_000e18, 500_000_000e18);
-        initialize(alice, fixedRate, contribution);
+        INITIAL_CONTRIBUTION = contribution;
+        super.setUp();
 
         // Ensure that the max long is actually the max long.
         _verifyMaxLong(

--- a/test/everlong/units/Tend.t.sol
+++ b/test/everlong/units/Tend.t.sol
@@ -130,7 +130,7 @@ contract TestTend is EverlongTest {
     ///      position.
     function test_tendTrigger_with_matured_position() external {
         // Mint some tokens to Everlong for opening longs and rebalance.
-        mintApproveBaseAsset(address(strategy), MINIMUM_TRANSACTION_AMOUNT + 1);
+        mintApproveAsset(address(strategy), MINIMUM_TRANSACTION_AMOUNT + 1);
         rebalance();
 
         // Increase block.timestamp until position is mature.


### PR DESCRIPTION
- add test using hyperdrive's vaultSharesToken via asBase=false
- add category as an optional parameter when deploying a vault
- add accommodations for legacy hyperdrive instances that lack external `convertToBase()` and `convertToShares()` functions