### PR TITLE
correctly convert base token denominated values from hyperdrive

### DIFF
--- a/contracts/libraries/HyperdriveExecution.sol
+++ b/contracts/libraries/HyperdriveExecution.sol
@@ -492,15 +492,18 @@ library HyperdriveExecutionLibrary {
     // HACK: Copied from `delvtech/hyperdrive` repo.
     //
     /// @dev Calculates the maximum amount of longs that can be opened.
+    /// @param _asBase Whether to transact using hyperdrive's base or vault
+    ///                shares token.
     /// @param _maxIterations The maximum number of iterations to use.
-    /// @return baseAmount The cost of buying the maximum amount of longs.
+    /// @return amount The cost of buying the maximum amount of longs.
     function calculateMaxLong(
         IHyperdrive self,
+        bool _asBase,
         uint256 _maxIterations
-    ) internal view returns (uint256 baseAmount) {
+    ) internal view returns (uint256 amount) {
         IHyperdrive.PoolConfig memory poolConfig = self.getPoolConfig();
         IHyperdrive.PoolInfo memory poolInfo = self.getPoolInfo();
-        (baseAmount, ) = calculateMaxLong(
+        (amount, ) = calculateMaxLong(
             MaxTradeParams({
                 shareReserves: poolInfo.shareReserves,
                 shareAdjustment: poolInfo.shareAdjustment,
@@ -518,17 +521,28 @@ library HyperdriveExecutionLibrary {
             self.getCheckpointExposure(latestCheckpoint(self)),
             _maxIterations
         );
-        return baseAmount;
+
+        // The above `amount` is denominated in hyperdrive's base token.
+        // If `_asBase == false` then hyperdrive's vault shares token is being
+        // used and we must convert the value.
+        if (!_asBase) {
+            amount = _convertToShares(self, amount);
+        }
+
+        return amount;
     }
 
     // HACK: Copied from `delvtech/hyperdrive` repo.
     //
     /// @dev Calculates the maximum amount of longs that can be opened.
+    /// @param _asBase Whether to transact using hyperdrive's base or vault
+    ///                shares token.
     /// @return baseAmount The cost of buying the maximum amount of longs.
     function calculateMaxLong(
-        IHyperdrive self
+        IHyperdrive self,
+        bool _asBase
     ) internal view returns (uint256 baseAmount) {
-        return calculateMaxLong(self, 7);
+        return calculateMaxLong(self, _asBase, 7);
     }
 
     // HACK: Copied from `delvtech/hyperdrive` repo.

--- a/test/everlong/integration/PartialClosures.t.sol
+++ b/test/everlong/integration/PartialClosures.t.sol
@@ -25,7 +25,7 @@ contract TestPartialClosures is EverlongTest {
         uint256 aliceDepositAmount = bound(
             _deposit,
             MINIMUM_TRANSACTION_AMOUNT * 100, // Increase minimum bound otherwise partial redemption won't occur
-            hyperdrive.calculateMaxLong()
+            hyperdrive.calculateMaxLong(AS_BASE)
         );
         uint256 aliceShares = depositStrategy(aliceDepositAmount, alice, true);
         uint256 positionBondsAfterDeposit = IEverlongStrategy(address(strategy))

--- a/test/everlong/integration/Sandwich.t.sol
+++ b/test/everlong/integration/Sandwich.t.sol
@@ -42,7 +42,7 @@ contract TestSandwichHelper is EverlongTest {
         _bystanderDeposit = bound(
             _bystanderDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 bystanderShares = depositVault(
             _bystanderDeposit,
@@ -67,7 +67,7 @@ contract TestSandwichHelper is EverlongTest {
         _attackerDeposit = bound(
             _attackerDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 attackerShares = depositVault(
             _attackerDeposit,
@@ -125,7 +125,7 @@ contract TestSandwichHelper is EverlongTest {
         _bystanderDeposit = bound(
             _bystanderDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 bystanderShares = depositVault(
             _bystanderDeposit,
@@ -139,7 +139,7 @@ contract TestSandwichHelper is EverlongTest {
         _attackerDeposit = bound(
             _attackerDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 attackerShares = depositVault(
             _attackerDeposit,
@@ -212,7 +212,7 @@ contract TestSandwichHelper is EverlongTest {
         _bystanderDeposit = bound(
             _bystanderDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 bystanderEverlongShares = depositVault(
             _bystanderDeposit,
@@ -226,7 +226,7 @@ contract TestSandwichHelper is EverlongTest {
         _attackerDeposit = bound(
             _attackerDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 attackerEverlongShares = depositVault(
             _attackerDeposit,
@@ -279,7 +279,7 @@ contract TestSandwichHelper is EverlongTest {
         _bystanderDeposit = bound(
             _bystanderDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 bystanderShares = depositVault(
             _bystanderDeposit,
@@ -293,7 +293,7 @@ contract TestSandwichHelper is EverlongTest {
         _attackerDeposit = bound(
             _attackerDeposit,
             MINIMUM_TRANSACTION_AMOUNT * 5,
-            hyperdrive.calculateMaxLong() / 3
+            hyperdrive.calculateMaxLong(AS_BASE) / 3
         );
         uint256 attackerShares = depositVault(
             _attackerDeposit,

--- a/test/everlong/units/HyperdriveExecution.t.sol
+++ b/test/everlong/units/HyperdriveExecution.t.sol
@@ -206,7 +206,7 @@ contract TestHyperdriveExecution is EverlongTest {
         // decrease the value of the share adjustment to a non-trivial value.
         matureLongAmount = matureLongAmount.normalizeToRange(
             MINIMUM_TRANSACTION_AMOUNT + 1,
-            hyperdrive.calculateMaxLong() / 2
+            hyperdrive.calculateMaxLong(AS_BASE) / 2
         );
         openLong(alice, matureLongAmount);
         advanceTime(hyperdrive.getPoolConfig().positionDuration, 0);
@@ -343,7 +343,7 @@ contract TestHyperdriveExecution is EverlongTest {
         // value which stress tests the max long function.
         initialLongAmount = initialLongAmount.normalizeToRange(
             MINIMUM_TRANSACTION_AMOUNT + 1,
-            hyperdrive.calculateMaxLong() / 2
+            hyperdrive.calculateMaxLong(AS_BASE) / 2
         );
         openLong(bob, initialLongAmount);
         initialShortAmount = initialShortAmount.normalizeToRange(


### PR DESCRIPTION
Some values received from hyperdrive are denominated in base tokens.

These must be converted to vault shares token denominated values when `asBase==true || isWrapped==true` in the strategy