### PR TITLE
enforce that when `isWrapped=true`, `asBase=false`

### DIFF
--- a/contracts/EverlongStrategy.sol
+++ b/contracts/EverlongStrategy.sol
@@ -120,6 +120,7 @@ contract EverlongStrategy is BaseStrategy {
 
     /// @notice Whether to use Hyperdrive's base token to purchase bonds.
     ///         If false, use the Hyperdrive's `vaultSharesToken`.
+    /// @dev When `isWrapped=true`, `asBase` must be set to false.
     bool public immutable asBase;
 
     /// @notice Whether the strategy asset is a wrapped version of hyperdrive's
@@ -172,11 +173,20 @@ contract EverlongStrategy is BaseStrategy {
         bool _asBase,
         bool _isWrapped
     ) BaseStrategy(_asset, __name) {
+        // When the asset is wrapped, `_asBase` must be false.
+        if (_isWrapped && _asBase) {
+            revert IEverlongStrategy.WrappedBaseMismatch();
+        }
+
         // Store the hyperdrive instance's address.
         hyperdrive = _hyperdrive;
 
         // Store whether to interact with hyperdrive using its base token.
         asBase = _asBase;
+
+        // Store whether `asset` should be treated as a wrapped hyperdrive
+        // token.
+        isWrapped = _isWrapped;
 
         // Store the hyperdrive's PoolConfig since it's static.
         _poolConfig = IHyperdrive(_hyperdrive).getPoolConfig();
@@ -185,10 +195,6 @@ contract EverlongStrategy is BaseStrategy {
         executionToken = address(
             _asBase ? _poolConfig.baseToken : _poolConfig.vaultSharesToken
         );
-
-        // Store whether `asset` should be treated as a wrapped hyperdrive
-        // token.
-        isWrapped = _isWrapped;
     }
 
     // ╭───────────────────────────────────────────────────────────────────────╮

--- a/contracts/interfaces/IEverlongStrategy.sol
+++ b/contracts/interfaces/IEverlongStrategy.sol
@@ -40,6 +40,10 @@ interface IEverlongStrategy is IPermissionedStrategy, IEverlongEvents {
     ///         a non-wrapped asset.
     error AssetNotWrapped();
 
+    /// @notice Thrown when creating a strategy with both `isWrapped == true`
+    ///         and `isBase == true`.
+    error WrappedBaseMismatch();
+
     // ╭───────────────────────────────────────────────────────────────────────╮
     // │                                SETTERS                                │
     // ╰───────────────────────────────────────────────────────────────────────╯

--- a/test/everlong/units/Everlong.t.sol
+++ b/test/everlong/units/Everlong.t.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.20;
 
+import { console2 as console } from "forge-std/console2.sol";
 import { IEverlongStrategy } from "../../../contracts/interfaces/IEverlongStrategy.sol";
+import { EverlongStrategy } from "../../../contracts/EverlongStrategy.sol";
 import { EVERLONG_STRATEGY_KIND, EVERLONG_VERSION } from "../../../contracts/libraries/Constants.sol";
 import { EverlongTest } from "../EverlongTest.sol";
 
@@ -31,6 +33,20 @@ contract TestEverlong is EverlongTest {
             IEverlongStrategy(address(strategy)).version(),
             EVERLONG_VERSION,
             "version does not match"
+        );
+    }
+
+    /// @dev Tests that the error `IEverlongStrategy.WrappedBaseMismatch()` is
+    ///      thrown when creating a strategy with `isWrapped=true` and
+    ///      `asBase=true`.
+    function test_wrapped_isbase_true_failure() external {
+        vm.expectRevert();
+        new EverlongStrategy(
+            address(address(asset)),
+            "EverlongTest",
+            address(hyperdrive),
+            true,
+            true
         );
     }
 }


### PR DESCRIPTION
We currently assume that when using wrapping, `asBase=false` and the vault shares token from hyperdrive will be used.

This PR asserts the above assumption in the `EverlongStrategy` constructor.