### PR TITLE
15 - custom errors for keeper contract call failures

### DIFF
--- a/contracts/EverlongStrategyKeeper.sol
+++ b/contracts/EverlongStrategyKeeper.sol
@@ -14,6 +14,7 @@ import { DebtAllocator } from "vault-periphery/debtAllocators/DebtAllocator.sol"
 import { IVault } from "yearn-vaults-v3/interfaces/IVault.sol";
 import { Roles } from "yearn-vaults-v3/interfaces/Roles.sol";
 import { IEverlongStrategy } from "./interfaces/IEverlongStrategy.sol";
+import { IEverlongStrategyKeeper } from "./interfaces/IEverlongStrategyKeeper.sol";
 import { IRoleManager } from "./interfaces/IRoleManager.sol";
 import { EVERLONG_STRATEGY_KEEPER_KIND, EVERLONG_VERSION, ONE, MAX_BPS } from "./libraries/Constants.sol";
 import { EverlongPortfolioLibrary } from "./libraries/EverlongPortfolio.sol";
@@ -115,9 +116,7 @@ contract EverlongStrategyKeeper is Ownable {
                 vaultCalldataOrReason
             );
             if (!success) {
-                revert(
-                    string.concat("vault process_report failed: ", string(err))
-                );
+                revert IEverlongStrategyKeeper.VaultReportFailed(err);
             }
         }
     }
@@ -150,7 +149,7 @@ contract EverlongStrategyKeeper is Ownable {
                 strategyCalldataOrReason
             );
             if (!success) {
-                revert(string.concat("strategy report failed: ", string(err)));
+                revert IEverlongStrategyKeeper.StrategyReportFailed(err);
             }
         }
     }
@@ -178,7 +177,7 @@ contract EverlongStrategyKeeper is Ownable {
             IEverlongStrategy(_strategy).setTendConfig(_config);
             (bool success, bytes memory err) = _strategy.call(calldataOrReason);
             if (!success) {
-                revert(string.concat("strategy tend failed: ", string(err)));
+                revert IEverlongStrategyKeeper.TendFailed(err);
             }
         }
     }
@@ -209,9 +208,7 @@ contract EverlongStrategyKeeper is Ownable {
                 calldataOrReason
             );
             if (!success) {
-                revert(
-                    string.concat("vault update debt failed: ", string(err))
-                );
+                revert IEverlongStrategyKeeper.UpdateDebtFailed(err);
             }
         }
     }

--- a/contracts/interfaces/IEverlongStrategyKeeper.sol
+++ b/contracts/interfaces/IEverlongStrategyKeeper.sol
@@ -179,6 +179,18 @@ interface IEverlongStrategyKeeper {
     /// @notice The owner is not a valid owner account. (eg. `address(0)`)
     error OwnableInvalidOwner(address owner);
 
+    /// @notice Thrown when a strategy report reverts.
+    error StrategyReportFailed(bytes data);
+
+    /// @notice Thrown when `tend` reverts.
+    error TendFailed(bytes data);
+
+    /// @notice Thrown when `update_debt` reverts.
+    error UpdateDebtFailed(bytes data);
+
+    /// @notice Thrown when a vault report reverts.
+    error VaultReportFailed(bytes data);
+
     // ╭───────────────────────────────────────────────────────────────────────╮
     // │                                Events                                 │
     // ╰───────────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
This pr replaces the keeper contract's inline revert strings with custom errors for better readability. 

[issue](https://cantina.xyz/code/4f25dfd5-d3e6-4e7a-9481-d7306b795f2b/findings/15)